### PR TITLE
Export edited data as single Excel file and improve timeline display

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ matplotlib
 plotly
 fpdf
 datetime
+openpyxl


### PR DESCRIPTION
## Summary
- Allow exporting edited CSV data as a single Excel workbook including inputs
- Show milestone dates by default and let users customize legend position
- Add openpyxl dependency for Excel export

## Testing
- `pip install openpyxl` *(fails: Could not find a version that satisfies the requirement openpyxl)*
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba7aedb9388322bbab5884e569d4e5