### PR TITLE
Color tasks by group even with zero progress

### DIFF
--- a/app.py
+++ b/app.py
@@ -849,24 +849,26 @@ for i, row in enumerate(df_tasks.itertuples(index=False), start=1):
         progress = 0.0
     progress = max(0.0, min(progress / 100.0, 1.0))
 
-    # background bar
+    base_color = group_colors.get(row.group, default_color)
+    # background bar tinted by group color
     ax.barh(
         i,
         duration_num,
         left=start_num,
         height=bar_height,
         align='center',
-        color='lightgray',
+        color=base_color,
+        alpha=0.3,
         zorder=2,
     )
-    # progress bar
+    # progress bar (full color showing advancement)
     ax.barh(
         i,
         duration_num * progress,
         left=start_num,
         height=bar_height,
         align='center',
-        color=group_colors.get(row.group, default_color),
+        color=base_color,
         zorder=3,
     )
 


### PR DESCRIPTION
## Summary
- Tint task bars with their group color even when progress is zero
- Overlay progress bar retains full color for better advancement visibility

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba9c4337f08322ae8b1116879a644a