### PR TITLE
Add optional secondary x-axis for months or week numbers

### DIFF
--- a/app.py
+++ b/app.py
@@ -358,6 +358,11 @@ with tabs[0]:
         step=1,
     )
     date_fmt = st.text_input("Format des dates (strftime)", "%d %b %Y")
+    top_axis = st.selectbox(
+        "Graduations secondaires (haut)",
+        ["Aucune", "Mois", "Numéros de semaine"],
+        index=0,
+    )
 
 with tabs[1]:
     st.subheader("Plage X")
@@ -1086,6 +1091,15 @@ else:
     # step in weeks
     ax.xaxis.set_major_locator(mdates.WeekdayLocator(byweekday=mdates.MO, interval=int(x_tick_step)))
 ax.xaxis.set_major_formatter(mdates.DateFormatter(date_fmt))
+if top_axis != "Aucune":
+    sec_ax = ax.secondary_xaxis('top')
+    sec_ax.set_xlim(x_min_num, x_max_num)
+    if top_axis == "Mois":
+        sec_ax.xaxis.set_major_locator(mdates.MonthLocator())
+        sec_ax.xaxis.set_major_formatter(mdates.DateFormatter("%b"))
+    else:
+        sec_ax.xaxis.set_major_locator(mdates.WeekdayLocator(byweekday=mdates.MO))
+        sec_ax.xaxis.set_major_formatter(mdates.DateFormatter("%W"))
 plt.setp(ax.get_xticklabels(), rotation=rot, ha="right")
 
 # Grid


### PR DESCRIPTION
## Summary
- Add sidebar option to enable secondary top axis showing months or ISO week numbers.
- Plot secondary x-axis with appropriate locator and formatter, synced with primary axis limits.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba9e8c4d54832290808b1926432647