### PR TITLE
Split legend into milestone and activity columns

### DIFF
--- a/app.py
+++ b/app.py
@@ -1232,11 +1232,15 @@ if show_inputs and not df_inputs.empty:
             )
 
 handles = []
-for g, o in zip_longest(legend_groups, legend_other):
-    if g:
-        handles.append(g)
-    if o:
-        handles.append(o)
+# Assure that legend entries are split into two distinct columns:
+# one for milestones/other markers and one for activity groups.
+max_len = max(len(legend_groups), len(legend_other))
+for i in range(max_len):
+    # first column: milestones/other markers
+    o = legend_other[i] if i < len(legend_other) else Line2D([], [], linestyle="None", label="")
+    # second column: activity groups
+    g = legend_groups[i] if i < len(legend_groups) else Line2D([], [], linestyle="None", label="")
+    handles.extend([o, g])
 
 if handles:
     if legend_loc == "outside right":


### PR DESCRIPTION
## Summary
- ensure legend builds separate columns for milestones and activity groups
- maintain empty placeholders so columns don't mix when counts differ

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbea6542b88322802adc51302a5ff4