### PR TITLE
Set legend position default to outside right

### DIFF
--- a/app.py
+++ b/app.py
@@ -436,7 +436,7 @@ with tabs[1]:
                 "outside bottom",
                 "outside top",
             ],
-            index=0,
+            index=9,
             help="Emplacement de la légende du graphique",
         )
     with st.expander("Titres & Durées"):


### PR DESCRIPTION
## Summary
- default legend position is now "outside right" in the Streamlit selectbox

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbf3822c288322999c2cee6bde71f3