### PR TITLE
Add title styling controls in sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -360,6 +360,8 @@ uploaded_holidays = st.sidebar.file_uploader(
 
 st.sidebar.markdown("---")
 planning_title = st.sidebar.text_input("Titre du planning", "Planning")
+planning_title_size = st.sidebar.slider("Taille du titre", 8, 32, 16)
+planning_title_color = st.sidebar.color_picker("Couleur du titre", "#000000")
 unit = st.sidebar.selectbox(
     "Unité de temps",
     ["Jours", "Semaines"],
@@ -1423,7 +1425,7 @@ if show_ax_arrow:
 
 ax.set_xlabel("")
 ax.set_ylabel("")
-ax.set_title(planning_title)
+ax.set_title(planning_title, fontsize=planning_title_size, color=planning_title_color)
 
 st.pyplot(fig, use_container_width=True)
 


### PR DESCRIPTION
## Summary
- Add sidebar controls for planning title size and color
- Apply user-selected title size and color when drawing the Gantt chart

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbf4634c448322ac18da57a3d79a27