### PR TITLE
Fix expander_search expanded type error

### DIFF
--- a/app.py
+++ b/app.py
@@ -330,7 +330,7 @@ def _norm(s: str) -> str:
 
 def expander_search(label: str, keywords=None, default=False, **kwargs):
     keys = [label] + (keywords or [])
-    expanded = default or (search_term and any(_norm(search_term) in _norm(k) for k in keys))
+    expanded = default or (bool(search_term) and any(_norm(search_term) in _norm(k) for k in keys))
     return st.expander(label, expanded=expanded, **kwargs)
 
 SEARCH_CATALOG = {


### PR DESCRIPTION
## Summary
- ensure expander_search passes boolean `expanded` to Streamlit expander

## Testing
- `python -m pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0a0604a3c83229709e1d60ae8aefe